### PR TITLE
Fix fire police destroy event

### DIFF
--- a/server/sv_planting.lua
+++ b/server/sv_planting.lua
@@ -270,11 +270,12 @@ RegisterNetEvent('ps-weedplanting:server:PoliceDestroy', function(netId)
         MySQL.query('DELETE from weedplants WHERE id = :id', {
             ['id'] = WeedPlants[entity].id
         })
-        WeedPlants[entity] = nil
 
         TriggerClientEvent('ps-weedplanting:client:FireGoBrrrrrrr', -1, WeedPlants[entity].coords)
         Wait(Shared.FireTime)
         DeleteEntity(entity)
+
+        WeedPlants[entity] = nil
     end
 end)
 


### PR DESCRIPTION
The WeedPlants[entity] was getting reset to nil prior to the fire event taking place. 

This fixes this error: [script:ps-weedplanti] SCRIPT ERROR: @ps-weedplanting/server/sv_planting.lua:275: attempt to index a nil value (field '?')